### PR TITLE
Use the overriden fields index analyzer when doing term stats

### DIFF
--- a/lib/src/main/java/softwaredoug/solr/stats/ManagedStatsCache.java
+++ b/lib/src/main/java/softwaredoug/solr/stats/ManagedStatsCache.java
@@ -24,7 +24,16 @@ public class ManagedStatsCache extends LocalStatsCache {
 
     public ManagedStatsCache() {
         super();
-        log.info("Loading ManagedStatsCache");
+        log.warn("************************************************************");
+        log.warn("!!## ManagedStatsCache being used - this is for testing only");
+        log.warn("");
+        log.warn("");
+        log.warn("");
+        log.warn("");
+        log.warn("");
+        log.warn("");
+        log.warn("");
+        log.warn("************************************************************");
     }
 
     @Override

--- a/lib/src/main/java/softwaredoug/solr/stats/ManagedTextField.java
+++ b/lib/src/main/java/softwaredoug/solr/stats/ManagedTextField.java
@@ -85,7 +85,8 @@ public class ManagedTextField extends TextField implements ResourceLoaderAware {
                 long maxDocs = stats[1];
                 long sumTotalTermFreq = stats[2];
                 long sumTotalDocFreq = stats[3];
-                log.info("Loaded global stats for field: {} ", fieldName);
+                log.warn("*****************************************");
+                log.warn("USING MANAGED STATS FOR: {} ", fieldName);
                 fieldStats.put(fieldName,
                                 new CollectionStatistics(fieldName, maxDocs, docCount, sumTotalTermFreq, sumTotalDocFreq));
             }
@@ -125,12 +126,16 @@ public class ManagedTextField extends TextField implements ResourceLoaderAware {
         return this.override_all_fields;
     }
 
-    public TermStatistics termStatistics(Term term) {
+    public TermStatistics termStatistics(Term term, Analyzer indexAnalyzer) {
         log.trace("Lookup stats for term: {}", term.text());
+
+        if (indexAnalyzer == null) {
+            indexAnalyzer = this.getIndexAnalyzer();
+        }
 
         // slow for correctness, very bad to do this here
         for (AnalyzedTermStats stats: this.termStats) {
-            TermStatistics thisStat = stats.getStats(term.field(), this.getIndexAnalyzer());
+            TermStatistics thisStat = stats.getStats(term.field(), indexAnalyzer);
             if (thisStat != null && thisStat.term().equals(term.bytes()) && term.field().equals(stats.getField())) {
                 return thisStat;
             }

--- a/lib/src/test/java/softwaredoug/solr/stats/ManagedStatsCacheOverrideTest.java
+++ b/lib/src/test/java/softwaredoug/solr/stats/ManagedStatsCacheOverrideTest.java
@@ -41,6 +41,55 @@ public class ManagedStatsCacheOverrideTest extends SolrTestCaseJ4 {
     }
 
 
+    public void testSearchManagedUsesManagedFieldsAnalyzer() {
+        /* Check for these overrides:
+        text_stem,cat,1,2
+        text_stem,cats,3,4      # Most stemmed preferred, this is ignored
+        text_stem,policy,5,9
+         */
+        assertQ(
+                "search uses doc count",
+                req(
+                        "q", "cat",
+                        "qf", "text_stem",
+                        "defType", "edismax",
+                        "debug", "true"),
+                "//lst[@name='explain']/str[@name='4' and contains(text(),\"1 = n, number of documents containing term\")]");
+
+        assertQ(
+                "search uses doc count",
+                req(
+                        "q", "cats",
+                        "qf", "text_stem",
+                        "defType", "edismax",
+                        "debug", "true"),
+                "//lst[@name='explain']/str[@name='4' and contains(text(),\"1 = n, number of documents containing term\")]");
+
+
+    }
+
+    public void testSearchManagedUsesManagedFieldsStemmedOrigTerm() {
+        assertQ(
+                "search uses doc count",
+                req(
+                        "q", "policy",
+                        "qf", "text_stem",
+                        "defType", "edismax",
+                        "debug", "true"),
+                "//lst[@name='explain']/str[@name='4' and contains(text(),\"5 = n, number of documents containing term\")]");
+    }
+    public void testSearchManagedUsesManagedFieldsStemmedTerm() {
+        assertQ(
+                "search uses doc count",
+                req(
+                        "q", "policies",
+                        "qf", "text_stem",
+                        "defType", "edismax",
+                        "debug", "true"),
+                "//lst[@name='explain']/str[@name='4' and contains(text(),\"5 = n, number of documents containing term\")]");
+    }
+
+
     public void indexDocs() {
 
         assertU(adoc("id", "1",
@@ -50,6 +99,8 @@ public class ManagedStatsCacheOverrideTest extends SolrTestCaseJ4 {
         assertU(adoc("id", "3", "text", "foo", "not_managed", "burritos"
         ));
         assertU(adoc("id", "4", "text", "bar", "not_managed", "nachos"
+        ));
+        assertU(adoc("id", "4", "text", "policy cat cats", "not_managed", "nachos"
         ));
         assertU(commit());
     }

--- a/lib/src/test/java/softwaredoug/solr/stats/ManagedStatsFieldTest.java
+++ b/lib/src/test/java/softwaredoug/solr/stats/ManagedStatsFieldTest.java
@@ -55,7 +55,7 @@ public class ManagedStatsFieldTest extends SolrTestCaseJ4 {
     public void testGetsStatsForField() {
         BytesRef text = new BytesRef("foo".getBytes());
         Term term = new Term("text", text);
-        TermStatistics termStats = this.managedField.termStatistics(term);
+        TermStatistics termStats = this.managedField.termStatistics(term, null);
 
         assertNotNull(termStats);
         assertEquals(term.bytes(), termStats.term());
@@ -67,7 +67,7 @@ public class ManagedStatsFieldTest extends SolrTestCaseJ4 {
     public void testTextAnalyzed() {
         BytesRef text = new BytesRef("uppercase".getBytes());
         Term term = new Term("text", text);
-        TermStatistics termStats = this.managedField.termStatistics(term);
+        TermStatistics termStats = this.managedField.termStatistics(term, null);
         assertNotNull(termStats);
     }
 
@@ -75,7 +75,7 @@ public class ManagedStatsFieldTest extends SolrTestCaseJ4 {
     public void testGetsNoStatsIfNoTermProduced() {
         BytesRef text = new BytesRef("stopword".getBytes());
         Term term = new Term("text", text);
-        TermStatistics termStats = this.managedField.termStatistics(term);
+        TermStatistics termStats = this.managedField.termStatistics(term, null);
         assertNull(termStats);
     }
 
@@ -83,7 +83,7 @@ public class ManagedStatsFieldTest extends SolrTestCaseJ4 {
     public void testAnalyzesToMultipleTermsIgnored() {
         BytesRef text = new BytesRef("two terms".getBytes());
         Term term = new Term("text", text);
-        TermStatistics termStats = this.managedField.termStatistics(term);
+        TermStatistics termStats = this.managedField.termStatistics(term, null);
         assertNull(termStats);
     }
 
@@ -91,7 +91,7 @@ public class ManagedStatsFieldTest extends SolrTestCaseJ4 {
     public void testAnalyzesCommaTermsCorrectly() {
         BytesRef text = new BytesRef("comma,term".getBytes());
         Term term = new Term("text", text);
-        TermStatistics termStats = this.managedField.termStatistics(term);
+        TermStatistics termStats = this.managedField.termStatistics(term, null);
         assertNull(termStats);
     }
 }

--- a/lib/src/test/resources/solr/collection1/conf/schema_override.xml
+++ b/lib/src/test/resources/solr/collection1/conf/schema_override.xml
@@ -20,8 +20,10 @@
   <fields>
     <field name="id" type="string" indexed="true" stored="true" required="true" multiValued="false" />
     <field name="text" type="text_general" indexed="true" stored="false" multiValued="true"/>
+    <field name="text_stem" type="text_stemmed" indexed="true" stored="false" multiValued="true"/>
     <field name="not_managed" type="non_managed" indexed="true" stored="false" multiValued="true"/>
     <field name="_version_" type="long" indexed="true" stored="true" />
+    <copyField source="text" dest="text_stem" />
   </fields>
 
   <uniqueKey>id</uniqueKey>
@@ -36,6 +38,22 @@
     <fieldType name="date" class="${solr.tests.DateFieldType}" docValues="${solr.tests.numeric.dv}" precisionStep="0" positionIncrementGap="0"/>
     <fieldtype name="binary" class="solr.BinaryField"/>
 
+    <fieldType name="text_stemmed"  class="solr.TextField" positionIncrementGap="100">
+    <analyzer type="index">
+      <tokenizer class="solr.StandardTokenizerFactory"/>
+      <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"  />
+      <filter class="solr.LowerCaseFilterFactory"/>
+      <filter class="solr.PorterStemFilterFactory"/>
+    </analyzer>
+    <analyzer type="query">
+      <tokenizer class="solr.StandardTokenizerFactory"/>
+      <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"  />
+      <filter class="solr.LowerCaseFilterFactory"/>
+      <filter class="solr.PorterStemFilterFactory"/>
+    </analyzer>
+    </fieldType>
+
+
     <fieldType name="text_general" class="softwaredoug.solr.stats.ManagedTextField" override="true" stats="text_stats_override.csv" positionIncrementGap="100">
       <analyzer type="index">
         <tokenizer class="solr.StandardTokenizerFactory"/>
@@ -49,6 +67,7 @@
         <filter class="solr.LowerCaseFilterFactory"/>
       </analyzer>
     </fieldType>
+
     <fieldType name="non_managed" class="solr.TextField" positionIncrementGap="100">
       <analyzer type="index">
         <tokenizer class="solr.StandardTokenizerFactory"/>

--- a/lib/src/test/resources/solr/collection1/conf/text_stats_override.csv
+++ b/lib/src/test/resources/solr/collection1/conf/text_stats_override.csv
@@ -7,6 +7,7 @@
 #
 fields
 text,10,11,13,13
+text_stem,10,11,13,13
 not_managed,50,51,52,52
 
 terms
@@ -24,3 +25,7 @@ not_managed,nachos,12,22
 
 # Doc freq should not be higher that total term freq
 # impossible_doc_freq,60,50
+
+text_stem,cat,1,2
+text_stem,cats,3,4
+text_stem,policy,5,9

--- a/lib/src/test/resources/solr/collection1/conf/text_stats_stem.csv
+++ b/lib/src/test/resources/solr/collection1/conf/text_stats_stem.csv
@@ -1,0 +1,6 @@
+fields
+text_stem,9999,9999,9999,9999
+terms
+text_stem,cat,647,712
+text_stem,cats,1017,1040
+text_stem,policy,8760,11133


### PR DESCRIPTION
We use a managed field type to sneak in the stats override,

However when we process a stats file, we need to be careful not to use THAT field's analysis, etc. Instead we need to use the field being configured in teh config file.

IE NOT "some analyzers

```
    <fieldType name="text_general" class="softwaredoug.solr.stats.ManagedTextField" override="true" stats="text_stats_override.csv" positionIncrementGap="100">
       <!-- some analyzers --->
```

BUT use the field from the override (`text_stats_override.csv`) such as `text_stem`'s analyzer when processing this line

```
text_stem,cats,3,4
```

